### PR TITLE
[fix] 뒤로가기 활성화 , 새로운 활동 추천 요청할때 남아있던 spareTime 초기화

### DIFF
--- a/src/app/home/sg-activity/page.tsx
+++ b/src/app/home/sg-activity/page.tsx
@@ -24,14 +24,21 @@ export default function SuggestActivity() {
   const [selectedActivity, setSeletedActivity] = useState<ActivityData>()
   const [activityLink, setActivityLink] = useState('')
   const [postActivityType, setPostActivityType] = useState('')
-  const { spareTime, address } = useActivityStore()
+  const { spareTime, setSpareTime, address } = useActivityStore()
   const router = useRouter()
 
   const handleBack = () => {
+    if (step === 1) {
+      setSpareTime('')
+      router.push('/home')
+      return
+    }
+
     setStep((prevStep) => {
       if (prevStep === 4 && !selectOnOff.includes('오프라인')) {
         return 2
       }
+
       return Math.max(prevStep - 1, 1)
     })
   }
@@ -84,7 +91,6 @@ export default function SuggestActivity() {
   }
 
   const progressBarWidth = `${(step / 4) * 100}%`
-
   return (
     <div className="w-full h-screen overflow-hidden">
       <HeaderWithBack onBack={handleBack} title="활동 추천받기">


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


---


## 📝 해야할 작업 Task
- [x] 뒤로가기 활성화
- [x] 새로운 활동 추천 요청할때 남아있던 spareTime 초기화


---


## 🔍 작업 세부 내용
![image](https://github.com/user-attachments/assets/b6e08acb-ddeb-4161-9c53-0943722b11b1)

추가로 활동 추천 플로우 도중 메인으로 나갔다 다시 활동 추천 플로우로 들어오면 이전에 입력했던 시간 값이 남아있습니다.
해당 값을 초기화했습니다.


---


## ✏️ 관련 이슈

