### PR TITLE
[fix] 빠른시작 자투리 시간 수정 시 useEffect() 의존성으로 인한 무한루프 수정

### DIFF
--- a/src/app/home/sg-activity/components/ChoiceTime.tsx
+++ b/src/app/home/sg-activity/components/ChoiceTime.tsx
@@ -66,7 +66,7 @@ export default function ChoiceTime({ setError }: SetErrorProps) {
     if (isInitialized) {
       handleChangeTime(spareTime)
     }
-  }, [spareTime, isInitialized, handleChangeTime])
+  }, [isInitialized])
 
   return (
     <div className="w-342 mx-auto mt-50">


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


---


## 📝 해야할 작업 Task
빠른시작 자투리 시간 수정 시 useEffect() 의존성으로 인한 무한루프 수정


---


## 🔍 작업 세부 내용

---


## ✏️ 관련 이슈

